### PR TITLE
Make it Django 1.9 compatible

### DIFF
--- a/mini_django.py
+++ b/mini_django.py
@@ -20,6 +20,31 @@ DATABASES = {'default': {}}  # required regardless of actual usage
 TEMPLATE_DIRS = (
     here('.'),  # Templates in current dir
 )
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'django.core.context_processors.tz',
+    'django.core.context_processors.request',
+)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': TEMPLATE_DIRS,
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': (
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.template.context_processors.request',
+            ),
+        },
+    },
+]
 SECRET_KEY = 'so so secret'
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -33,6 +58,8 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     here('static'),
 )
+
+SILENCED_SYSTEM_CHECKS = ['1_8.W001']  # Silance warning for using TEMPLATE_*
 
 if not settings.configured:
     settings.configure(**locals())


### PR DESCRIPTION
Preserve backwards compatibility with older version of Django (tested with 1.5, 1.6, 1.7, 1.8, 1.9)

When  #4 is merged this will be compatible with 1.10 also