### PR TITLE
Django3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,9 @@ RUN pip install -r /requirements.txt
 
 COPY . /app
 WORKDIR /app
-CMD python ./mini_django.py runserver 0.0.0.0:${PORT:-8000}
+
+# Run mini_django using Django's dev server
+CMD python mini_django.py runserver 0.0.0.0:${PORT:-8000}
+
+# uncomment the line below to run the mini_api server instead
+# CMD python mini_api.py runserver 0.0.0.0:${PORT:-8000}

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ and go to http://localhost:8000
 
 Production
 ==========
-You can also run these Django projects production-like mode using a WSGI server
-like `uWSGI` or `gunicorn`. 
+You can also run these Django projects in production-like mode using a WSGI server
+like `uWSGI` or `gunicorn`.
 
 uWSGI
 -----
@@ -110,3 +110,9 @@ As-is. Public Domain. Don't blame me.
 Author
 ======
 Tim Watts (tim@readevalprint.com) [@readevalprint](https://twitter.com/readevalprint)
+
+
+Contributors
+============
+Ivan Savov (ivan@minireference.com) [@minireference](https://twitter.com/minireference)
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 [![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/readevalprint/mini-django)
 
+Mini-Django
+===========
+An entire django app in a single file. Updated from [here](http://olifante.blogs.com/covil/2010/04/minimal-django.html) to use Django trunk. Works with Django 1.11, 2.x, and 3.x.
+
+
 Quick Start
 ===========
 
@@ -8,62 +13,99 @@ Clone https://github.com/readevalprint/mini-django
     $ docker build . -t mini-django
     $ docker run -p 8000:8000 -v `pwd`:/app mini-django
 
-and go to http://localhost:8000/Foo
+and go to http://localhost:8000/Foo. You can change the code in `mini_django.py`
+and the server will automatically reload as soon as you save your changes.
 
-Mini_django.py
-==============
 
-An entire django app in a single file. Updated from [here](http://olifante.blogs.com/covil/2010/04/minimal-django.html) to use Django trunk.
-Works with Django 1.1 and 2.1.
+Dependencies
+============
+* python3
+* django
+* [uWSGI](https://uwsgi-docs.readthedocs.io) (optional)
+* [django rest framework](http://django-rest-framework.org) (optional)
+
+
+Install
+=======
+1. Clone this repo
+2. (optional) Create a virtualenv `virtualenv -p python3 venv`
+   and activate it using `source venv/bin/activate`.
+3. Install Python dependencies `pip install -r requirements.txt`
+4. You can now run the three sample servers using one of the commands below:
+   - `PYTHONPATH=. django-admin.py runserver 0.0.0.0:8000 --settings=pico_django`
+   - `python mini_django.py runserver`
+   - `python mini_api.py runserver`
+
+
 
 pico
 ====
-This started off to see what the absolutely smallest requirements needed to run a Django project. Run the [pico_django.py](https://github.com/readevalprint/mini-django/blob/master/pico_django.py) with `$ PYTHONPATH=. django-admin.py runserver 0.0.0.0:8000 --settings=pico_django` and go to http://localhost:8000
+This started off to see what the absolutely smallest requirements needed to run a Django project. Run the [pico_django.py](https://github.com/readevalprint/mini-django/blob/master/pico_django.py) with:
 
-Or with uwsgi in production:
+    $ PYTHONPATH=. django-admin.py runserver 0.0.0.0:8000 --settings=pico_django
 
-    $ uwsgi --http :8000 -M --pythonpath=. 
-    --env DJANGO_SETTINGS_MODULE=pico_django \
-    -w "django.core.wsgi:get_wsgi_application()"
+You can then go to http://localhost:8000 to see the running server.
+
 
 mini
 ====
 Soon pico needed a little more spice, so it got some template loading and then because I'm lazy I made the new version directly runnable. Run the [mini_django.py](https://github.com/readevalprint/mini-django/blob/master/mini_django.py) with 
 
-    $ python ./mini_django.py runserver 0.0.0.0:8000
+    $ python mini_django.py runserver
     
 and go to http://localhost:8000/Foo
 
 
 api
 ===
-
 Often I need to use django-rest-framework for a simple one-off task, thankfully, mini_django can be adapted quite easily into [mini_api.py](https://github.com/readevalprint/mini-django/blob/master/mini_api.py)
 
-    $ python ./mini_api.py runserver 0.0.0.0:8000
+    $ python mini_api.py runserver
     
 and go to http://localhost:8000
 
 
-Dependencies
-===========
-* python
-* django
-* [uWSGI](https://uwsgi-docs.readthedocs.io) (optional)
-* [django rest framework](http://django-rest-framework.org) (optional)
 
-Install
-======
-1. Clone this repo
-2. `pip install django`
-3. Run
-    1. `python ./mini_django.py runserver 0.0.0.0:8000`
-    2. `PYTHONPATH=. django-admin.py runserver 0.0.0.0:8000 --settings=pico_django`
+Production
+==========
+You can also run these Django projects production-like mode using a WSGI server
+like `uWSGI` or `gunicorn`. 
+
+uWSGI
+-----
+First run `pip install uwsgi` to install the uWSGI package (requires build tools).
+You can then start the server using:
+
+    $ uwsgi --http :8000 -M --pythonpath=. \
+        --env DJANGO_SETTINGS_MODULE=mini_django \
+        -w "django.core.wsgi:get_wsgi_application()"
+
+Replace `mini_django` with `pico_django` or `mini_api` to run the other projects.
+
+gunicorn
+--------
+First install gunicorn using `pip install gunicorn`, then start the server using:
+
+    $ gunicorn --bind 0.0.0.0:8000 \
+        --env DJANGO_SETTINGS_MODULE=mini_django \
+        "django.core.wsgi:get_wsgi_application()"
+
+
+Replace `mini_django` with `pico_django` or `mini_api` to run the other projects.
+
+
+Disclaimer
+----------
+Note the above "production" examples are only given as POC to show the code works
+and not recommended for use in a real production environment. You'd need to think
+about number of WSGI workers, using NGINX to serve static files, and other such.
+
 
 
 License
 =======
 As-is. Public Domain. Don't blame me.
+
 
 Author
 ======

--- a/mini_django.py
+++ b/mini_django.py
@@ -1,60 +1,57 @@
 """
-Run this with `$ python ./mini_django.py runserver` and go
-to http://localhost:8000/
+Run with `python mini_django.py runserver` and go to http://localhost:8000/.
 """
+from os.path import abspath, dirname, join
 
+import django
+from django.conf import settings
 from django.urls import path
 from django.shortcuts import render
-import os
-import sys
-from django.conf import settings
-
-
-# this module
-me = os.path.splitext(os.path.split(__file__)[1])[0]
-
-# helper function to locate this dir
-def here(x):
-    return os.path.join(os.path.abspath(os.path.dirname(__file__)), x)
 
 
 # SETTINGS
+BASE_DIR = dirname(abspath(__file__))
 DEBUG = True
-ROOT_URLCONF = me
+ROOT_URLCONF = "mini_django"  # this module
 DATABASES = {"default": {}}  # required regardless of actual usage
-
-
 TEMPLATES = [
-    {"BACKEND": "django.template.backends.django.DjangoTemplates", "DIRS": here(".")}
+    {"BACKEND": "django.template.backends.django.DjangoTemplates", "DIRS": [BASE_DIR,]}
 ]
-
-
 STATIC_URL = "/static/"
-STATICFILES_DIRS = (here("static"),)
+STATICFILES_DIRS = (join(BASE_DIR, "static"),)
+SECRET_KEY = "not so secret",
 
-
+SETTINGS = dict((key,val) for key, val in locals().items() if key.isupper())
 if not settings.configured:
-    settings.configure(**locals())
+    settings.configure(**SETTINGS)
+django.setup()
+
 
 # Settings must be configured before importing some things like staticfiles
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 
+
 # VIEW
+
 def index(request, name=None):
     return render(request, "index.html", {"name": name})
 
 
+
 # URLS
 
-urlpatterns = [path("", index), path("<str:name>", index, name="named")]
-
+urlpatterns = [
+    path("", index),
+    path("<str:name>", index, name="named")
+]
 urlpatterns += staticfiles_urlpatterns()
 
-if __name__ == "__main__":
-    # set the ENV
-    sys.path += (here("."),)
-    # run the development server
-    from django.core import management
 
+
+# CLI
+
+if __name__ == "__main__":
+    # make this script runnable like a normal `manage.py` command line script.
+    from django.core import management
     management.execute_from_command_line()

--- a/pico_django.py
+++ b/pico_django.py
@@ -21,5 +21,5 @@ SECRET_KEY = "not so secret"
 # run with djagno dev server
 # $ PYTHONPATH=. django-admin.py runserver 0.0.0.0:8000 --settings=pico_django
 
-# for example run with uwsgi
-# `$ uwsgi --http :8000 -M --pythonpath=. --env DJANGO_SETTINGS_MODULE=pico_django -w "django.core.wsgi:get_wsgi_application()"`
+# for example run with uWSGI
+# $ uwsgi --http :8000 -M --pythonpath=. --env DJANGO_SETTINGS_MODULE=pico_django -w "django.core.wsgi:get_wsgi_application()"


### PR DESCRIPTION
I updated the call to `settings.confgure` to  use only the ALL_CAPS variables (see https://github.com/readevalprint/mini-django/issues/8).

While doing some tests with the "production" setup, I ran into several problems (App Registry not ready + templates not being found), which seems to be cause by django.setup() not being called, so I had to add that too.

Note I changed a bunch of other things in the code to cleanup and simplify. I think all changes are in the spirit of the orignal code, but if you don't like I can rework this PR to be "minimal" (i.e. change only the parts needed to make it work with Django 3).